### PR TITLE
Fix lint errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - '12'
+  - '10'
   - '8'
-  - '6'
-  - '4'

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ const check = file => {
 
 			return path.join(file, String(process.getuid()));
 		})
-		.catch(err => {
-			if (err.code === 'ENOENT') {
+		.catch(error => {
+			if (error.code === 'ENOENT') {
 				return topuid;
 			}
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ import path from 'path';
 import test from 'ava';
 import xdgBasedir from 'xdg-basedir';
 import execa from 'execa';
-import trashdir from '../';
+import trashdir from '..';
 
 test('get the trash path', async t => {
 	const dir = await trashdir();


### PR DESCRIPTION
I.e. fix the following failures in `npm test` -

  test/test.js
  ✖   6:1   Do not reference the index file directly
            unicorn/import-index
  ✖   6:22  Useless path segments for "../", should be ".."
            import/no-useless-path-segments

  index.js:22:10
  ✖  22:10  The catch parameter should be named error.
            unicorn/catch-error-name